### PR TITLE
baseStyle shouldnt work when there's custom styles

### DIFF
--- a/src/stripeElements.js
+++ b/src/stripeElements.js
@@ -43,7 +43,7 @@ function init(key, options = {}) {
 
 export function create(elementType, key_or_stripe, options = {}) {
   init(key_or_stripe, options.elements || {})
-  options.style = Object.assign(baseStyle, options.style || {})
+  options.style = Object.assign({}, options.style || baseStyle)
 
   const element = Stripe.elements.create(elementType, options)
 


### PR DESCRIPTION
When options.style is passed onto an element, the default styles should completely go away.

On top of my head, it's useful when you just want to design the card elements with the `classes` option https://stripe.com/docs/stripe-js/reference#element-options, you can just pass `style:  {}` to undo the default styles.