### PR TITLE
Added PaymentIntents API

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,4 +152,15 @@ export default {
 }
 </style>
 ```
+## Supported Stripe Elements Functions
 
+|Function|Reference|
+|---|---|
+| createToken() | https://stripe.com/docs/stripe-js/reference#stripe-create-token |
+| createSource() | https://stripe.com/docs/stripe-js/reference#stripe-create-source |
+| retrieveSource() | https://stripe.com/docs/stripe-js/reference#stripe-retrieve-source |
+| paymentRequest() | https://stripe.com/docs/stripe-js/reference#stripe-payment-request |
+| redirectToCheckout() | https://stripe.com/docs/stripe-js/reference#stripe-redirect-to-checkout |
+| retrievePaymentIntent() | https://stripe.com/docs/stripe-js/reference#stripe-retrieve-payment-intent |
+| handleCardPayment() | https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment |
+<!-- | confirmPaymentIntent() | https://stripe.com/docs/stripe-js/reference#stripe-confirm-payment-intent | -->

--- a/README.md
+++ b/README.md
@@ -163,4 +163,6 @@ export default {
 | redirectToCheckout() | https://stripe.com/docs/stripe-js/reference#stripe-redirect-to-checkout |
 | retrievePaymentIntent() | https://stripe.com/docs/stripe-js/reference#stripe-retrieve-payment-intent |
 | handleCardPayment() | https://stripe.com/docs/stripe-js/reference#stripe-handle-card-payment |
-<!-- | confirmPaymentIntent() | https://stripe.com/docs/stripe-js/reference#stripe-confirm-payment-intent | -->
+| handleCardSetup() | https://stripe.com/docs/stripe-js/reference#stripe-handle-card-setup |
+| confirmPaymentIntent() | https://stripe.com/docs/stripe-js/reference#stripe-confirm-payment-intent |
+| createPaymentMethod() | https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method |

--- a/src/index.js
+++ b/src/index.js
@@ -18,5 +18,9 @@ module.exports = {
   get instance() { return Stripe.instance },
   get createToken() { return Stripe.createToken },
   get createSource() { return Stripe.createSource },
-  get retrieveSource() { return Stripe.retrieveSource }
+  get retrieveSource() { return Stripe.retrieveSource },
+  get paymentRequest() { return Stripe.paymentRequest },
+  get redirectToCheckout() { return Stripe.redirectToCheckout },
+  get retrievePaymentIntent() { return Stripe.retrievePaymentIntent },
+  get handleCardPayment() { return Stripe.handleCardPayment }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -23,6 +23,7 @@ module.exports = {
   get redirectToCheckout() { return Stripe.redirectToCheckout },
   get retrievePaymentIntent() { return Stripe.retrievePaymentIntent },
   get handleCardPayment() { return Stripe.handleCardPayment },
+  get handleCardSetup() { return Stripe.handleCardSetup },
   get confirmPaymentIntent() { return Stripe.confirmPaymentIntent },
   get createPaymentMethod() { return Stripe.createPaymentMethod }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -22,5 +22,7 @@ module.exports = {
   get paymentRequest() { return Stripe.paymentRequest },
   get redirectToCheckout() { return Stripe.redirectToCheckout },
   get retrievePaymentIntent() { return Stripe.retrievePaymentIntent },
-  get handleCardPayment() { return Stripe.handleCardPayment }
+  get handleCardPayment() { return Stripe.handleCardPayment },
+  get confirmPaymentIntent() { return Stripe.confirmPaymentIntent },
+  get createPaymentMethod() { return Stripe.createPaymentMethod }
 }

--- a/src/stripeElements.js
+++ b/src/stripeElements.js
@@ -7,6 +7,7 @@ export const Stripe = {
   redirectToCheckout: null,
   retrievePaymentIntent: null,
   handleCardPayment: null,
+  handleCardSetup: null,
   confirmPaymentIntent: null,
   createPaymentMethod: null,
   elements: null
@@ -60,9 +61,10 @@ export function create(elementType, key_or_stripe, options = {}) {
   Stripe.redirectToCheckout = (options) => Stripe.instance.redirectToCheckout(options)
   Stripe.retrievePaymentIntent = (clientSecret) => Stripe.instance.retrievePaymentIntent(clientSecret)
   Stripe.handleCardPayment = (clientSecret, data) => Stripe.instance.handleCardPayment(clientSecret, element, data)
+  Stripe.handleCardSetup = (clientSecret, data) => Stripe.instance.handleCardSetup(clientSecret, element, data)
   Stripe.confirmPaymentIntent = (clientSecret, data) => Stripe.instance.confirmPaymentIntent(clientSecret, element, data)
   Stripe.createPaymentMethod = (cardType, data) => Stripe.instance.createPaymentMethod(cardType, element, data)
-
+  
   return element
 }
 
@@ -76,6 +78,7 @@ export function destroy() {
     Stripe.redirectToCheckout = null
     Stripe.retrievePaymentIntent = null
     Stripe.handleCardPayment = null
+    Stripe.handleCardSetup = null
     Stripe.confirmPaymentIntent = null
     Stripe.createPaymentMethod = null
 }

--- a/src/stripeElements.js
+++ b/src/stripeElements.js
@@ -3,6 +3,11 @@ export const Stripe = {
   createToken: null,
   createSource: null,
   retrieveSource: null,
+  paymentRequest: null,
+  redirectToCheckout: null,
+  retrievePaymentIntent: null,
+  handleCardPayment: null,
+  confirmPaymentIntent: null,
   elements: null
 }
 
@@ -47,9 +52,14 @@ export function create(elementType, key_or_stripe, options = {}) {
 
   const element = Stripe.elements.create(elementType, options)
 
-  Stripe.createToken = (options) => Stripe.instance.createToken(element, options)
-  Stripe.createSource = (options) => Stripe.instance.createSource(element, options)
-  Stripe.retrieveSource = (options) => Stripe.instance.retrieveSource(options)
+  Stripe.createToken = (tokenData) => Stripe.instance.createToken(element, tokenData)
+  Stripe.createSource = (sourceData) => Stripe.instance.createSource(element, sourceData)
+  Stripe.retrieveSource = (source) => Stripe.instance.retrieveSource(source)
+  Stripe.paymentRequest = (options) => Stripe.instance.paymentRequest(options)
+  Stripe.redirectToCheckout = (options) => Stripe.instance.redirectToCheckout(options)
+  Stripe.retrievePaymentIntent = (clientSecret) => Stripe.instance.retrievePaymentIntent(clientSecret)
+  Stripe.handleCardPayment = (clientSecret, data) => Stripe.instance.handleCardPayment(clientSecret, element, data)
+  Stripe.confirmPaymentIntent = (clientSecret, data) => Stripe.instance.confirmPaymentIntent(clientSecret, element, data)
 
   return element
 }
@@ -60,4 +70,9 @@ export function destroy() {
     Stripe.createToken = null
     Stripe.createSource = null
     Stripe.retrieveSource = null
+    Stripe.paymentRequest = null
+    Stripe.redirectToCheckout = null
+    Stripe.retrievePaymentIntent = null
+    Stripe.handleCardPayment = null
+    Stripe.confirmPaymentIntent = null
 }

--- a/src/stripeElements.js
+++ b/src/stripeElements.js
@@ -8,6 +8,7 @@ export const Stripe = {
   retrievePaymentIntent: null,
   handleCardPayment: null,
   confirmPaymentIntent: null,
+  createPaymentMethod: null,
   elements: null
 }
 
@@ -60,6 +61,7 @@ export function create(elementType, key_or_stripe, options = {}) {
   Stripe.retrievePaymentIntent = (clientSecret) => Stripe.instance.retrievePaymentIntent(clientSecret)
   Stripe.handleCardPayment = (clientSecret, data) => Stripe.instance.handleCardPayment(clientSecret, element, data)
   Stripe.confirmPaymentIntent = (clientSecret, data) => Stripe.instance.confirmPaymentIntent(clientSecret, element, data)
+  Stripe.createPaymentMethod = (cardType, data) => Stripe.instance.createPaymentMethod(cardType, element, data)
 
   return element
 }
@@ -75,4 +77,5 @@ export function destroy() {
     Stripe.retrievePaymentIntent = null
     Stripe.handleCardPayment = null
     Stripe.confirmPaymentIntent = null
+    Stripe.createPaymentMethod = null
 }


### PR DESCRIPTION
Expose additional calls to allow using the library with the new PaymentIntents api

Small refactor to clarify the calls into the underlying Stripe library